### PR TITLE
fix: Http example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea
 *.iml
 
+.DS_Store
+
 build/_maven_dependencies
 build/_output
 

--- a/examples/http.feature
+++ b/examples/http.feature
@@ -1,7 +1,7 @@
 Feature: Integration Works
 
   Background:
-    Given URL: https://www.wikipedia.org
+    Given URL: https://swapi.co/api/films
 
   Scenario: Get a result from API
     When send GET /

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -71,6 +71,11 @@
                 <artifactId>yaks-testing-camel-k</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>dev.yaks</groupId>
+                <artifactId>yaks-testing-http</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -120,6 +125,7 @@
     <modules>
         <module>yaks-testing</module>
         <module>yaks-testing-camel-k</module>
+        <module>yaks-testing-http</module>
     </modules>
 
     <profiles>

--- a/java/yaks-testing-http/pom.xml
+++ b/java/yaks-testing-http/pom.xml
@@ -26,36 +26,38 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>yaks-testing</artifactId>
+    <artifactId>yaks-testing-http</artifactId>
 
     <dependencies>
 
-        <!-- ****************************** -->
-        <!--                                -->
-        <!-- RUNTIME                        -->
-        <!--                                -->
-        <!-- ****************************** -->
-
-        <dependency>
-            <groupId>dev.yaks</groupId>
-            <artifactId>yaks-testing-camel-k</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>dev.yaks</groupId>
-            <artifactId>yaks-testing-http</artifactId>
-        </dependency>
-
-        <!-- ****************************** -->
-        <!--                                -->
-        <!-- OTHERS                         -->
-        <!--                                -->
-        <!-- ****************************** -->
-
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-junit</artifactId>
+            <artifactId>cucumber-java</artifactId>
             <version>${cucumber.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-cucumber</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-core</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-java-dsl</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-http</artifactId>
+            <version>${citrus.version}</version>
         </dependency>
 
     </dependencies>

--- a/java/yaks-testing-http/src/main/java/dev/yaks/testing/http/HttpConfiguration.java
+++ b/java/yaks-testing-http/src/main/java/dev/yaks/testing/http/HttpConfiguration.java
@@ -1,0 +1,20 @@
+package dev.yaks.testing.http;
+
+import com.consol.citrus.dsl.endpoint.CitrusEndpoints;
+import com.consol.citrus.http.client.HttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Configuration
+public class HttpConfiguration {
+
+    @Bean
+    public HttpClient defaultHttpClient() {
+        return CitrusEndpoints.http()
+                              .client()
+                              .build();
+    }
+}

--- a/java/yaks-testing/src/main/resources/citrus-application.properties
+++ b/java/yaks-testing/src/main/resources/citrus-application.properties
@@ -1,0 +1,2 @@
+citrus.spring.java.config=dev.yaks.testing.http.HttpConfiguration
+citrus.default.message.type=JSON


### PR DESCRIPTION
The http example needs a default http client in Citrus Spring application context. Also introduced a new testing-http module where we can add some more advanced Http steps.

One day these Http steps can be moved to Citrus but for now it should be easier to develop here.