### PR TITLE
Fix #8: unify yaks and yaks-cli and add release scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ build/_maven_dependencies
 build/_output
 
 /yaks
-/yaks-cli
+/yaks-*
 
 target/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Proof of Concept**
 
-YAKS (Yeat Another Kamel Subproject)
+YAKS (Yet Another Kamel Subproject)
 
 ## Usage
 
@@ -13,16 +13,16 @@ make && make images-dev
 
 # Once per cluster
 oc login -u system:admin
-./yaks-cli install --cluster-setup
+./yaks install --cluster-setup
 
 # Once per namespace
 oc login -u developer
 oc new-project yaks
-./yaks-cli install
+./yaks install
 
 # Run the test
 # expects a camel k integration named simple to be running and printing "Hello Camel"
-./yaks-cli test examples/simple.feature
+./yaks test examples/simple.feature
 
 # Check the status of all tests
 oc get tests

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,7 @@
 FROM fabric8/s2i-java:3.0-java8
 
 ENV OPERATOR=/usr/local/bin/yaks \
+    OPERATOR_ARGS=operator \
     USER_UID=1001 \
     USER_NAME=yaks \
     HOME=/root

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -9,4 +9,4 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec ${OPERATOR} $@
+exec ${OPERATOR} ${OPERATOR_ARGS} $@

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,162 +1,53 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
+	"math/rand"
 	"os"
-	"runtime"
+	"time"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
+	"github.com/jboss-fuse/yaks/pkg/cmd"
 
-	"github.com/jboss-fuse/yaks/pkg/apis"
-	"github.com/jboss-fuse/yaks/pkg/controller"
-
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
-	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
-	"github.com/operator-framework/operator-sdk/pkg/restmapper"
-	sdkVersion "github.com/operator-framework/operator-sdk/version"
-	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
-
-// Change below variables to serve metrics on different host or port.
-var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
-)
-var log = logf.Log.WithName("cmd")
-
-func printVersion() {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
-}
 
 func main() {
-	// Add the zap logger flag set to the CLI. The flag set must
-	// be added before calling pflag.Parse().
-	pflag.CommandLine.AddFlagSet(zap.FlagSet())
+	rand.Seed(time.Now().UTC().UnixNano())
 
-	// Add flags registered by imported packages (e.g. glog and
-	// controller-runtime)
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	ctx, cancel := context.WithCancel(context.Background())
 
-	pflag.Parse()
+	// Cancel ctx as soon as main returns
+	defer cancel()
 
-	// Use a zap logr.Logger implementation. If none of the zap
-	// flags are configured (or if the zap flag set is not being
-	// used), this defaults to a production zap logger.
-	//
-	// The logger instantiated here can be changed to any logger
-	// implementing the logr.Logger interface. This logger will
-	// be propagated through the whole operator, generating
-	// uniform and structured logs.
-	logf.SetLogger(zap.Logger())
+	rootCmd, err := cmd.NewYaksCommand(ctx)
+	exitOnError(err)
 
-	printVersion()
-
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
-	}
-
-	// Get a config to talk to the apiserver
-	cfg, err := config.GetConfig()
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
-	ctx := context.TODO()
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "yaks-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
-		MapperProvider:     restmapper.NewDynamicRESTMapper,
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-	})
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
-	log.Info("Registering Components.")
-
-	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
-	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
-	if err = serveCRMetrics(cfg); err != nil {
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-	}
-
-	// Add to the below struct any other metrics ports you want to expose.
-	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
-	}
-	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
-	if err != nil {
-		log.Info(err.Error())
-	}
-
-	log.Info("Starting the Cmd.")
-
-	// Start the Cmd
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Error(err, "Manager exited non-zero")
-		os.Exit(1)
-	}
+	err = rootCmd.Execute()
+	exitOnError(err)
 }
 
-// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
-// It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config) error {
-	// Below function returns filtered operator/CustomResource specific GVKs.
-	// For more control override the below GVK list with your own custom logic.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
+func exitOnError(err error) {
 	if err != nil {
-		return err
+		fmt.Println("Error:", err)
+
+		os.Exit(1)
 	}
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return err
-	}
-	// To generate metrics in other namespaces, add the values below.
-	ns := []string{operatorNs}
-	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,7 @@ spec:
           image: yaks/yaks:0.0.1
           command:
           - yaks
+          - operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/resources.go
+++ b/deploy/resources.go
@@ -48,6 +48,7 @@ spec:
           image: yaks/yaks:0.0.1
           command:
           - yaks
+          - operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+location=$(dirname $0)
+
+if [ "$#" -ne 0 ]; then
+    echo "usage: $0"
+    exit 1
+fi
+
+cd ${location}/../java
+
+rm -rf $PWD/../build/_maven_dependencies
+rm -rf $PWD/../build/_output

--- a/hack/cross_compile.sh
+++ b/hack/cross_compile.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+location=$(dirname $0)
+rootdir=$(realpath ${location}/..)
+
+basename=yaks
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 version"
+    exit 1
+fi
+
+version=$1
+
+cross_compile () {
+	local label=$1
+	local extension=""
+	export GOOS=$2
+	export GOARCH=$3
+
+	if [ "${GOOS}" == "windows" ]; then
+		extension=".exe"
+	fi
+
+	echo "Generating ${label}${extension}..."
+
+	go build -o ${rootdir}/${label}${extension} ./cmd/manager/...
+}
+
+cross_compile ${basename}-${version}-linux-64bit linux amd64
+cross_compile ${basename}-${version}-mac-64bit darwin amd64
+cross_compile ${basename}-${version}-windows-64bit windows amd64

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -32,10 +32,11 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) *cobra.Command {
 		RootCmdOptions: rootCmdOptions,
 	}
 	cmd := cobra.Command{
-		Use:   "install",
-		Short: "Install Yaks on a Kubernetes cluster",
-		Long:  `Installs Yaks on a Kubernetes or OpenShift cluster.`,
-		RunE:  impl.install,
+		PersistentPreRunE: impl.preRun,
+		Use:               "install",
+		Short:             "Install Yaks on a Kubernetes cluster",
+		Long:              `Installs Yaks on a Kubernetes or OpenShift cluster.`,
+		RunE:              impl.install,
 	}
 
 	cmd.Flags().BoolVar(&impl.clusterSetupOnly, "cluster-setup", false, "Execute cluster-wide operations only (may require admin rights)")

--- a/pkg/cmd/operator.go
+++ b/pkg/cmd/operator.go
@@ -15,39 +15,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cmd
 
 import (
-	"context"
-	"fmt"
-	"math/rand"
-	"os"
-	"time"
-
-	"github.com/jboss-fuse/yaks/pkg/cmd"
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"github.com/jboss-fuse/yaks/pkg/cmd/operator"
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
+func newCmdOperator(rootCmdOptions *RootCmdOptions) *cobra.Command {
+	impl := operatorCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+	cmd := cobra.Command{
+		Use:   "operator",
+		Short: "Run the Yaks operator",
+		Long:  `Run the Yaks operator locally.`,
+		Run:   impl.run,
+	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Cancel ctx as soon as main returns
-	defer cancel()
-
-	rootCmd, err := cmd.NewYaksCommand(ctx)
-	exitOnError(err)
-
-	err = rootCmd.Execute()
-	exitOnError(err)
+	return &cmd
 }
 
-func exitOnError(err error) {
-	if err != nil {
-		fmt.Println("Error:", err)
+type operatorCmdOptions struct {
+	*RootCmdOptions
+}
 
-		os.Exit(1)
-	}
+func (o *operatorCmdOptions) run(_ *cobra.Command, _ []string) {
+	operator.Run()
 }

--- a/pkg/cmd/operator/operator.go
+++ b/pkg/cmd/operator/operator.go
@@ -1,0 +1,162 @@
+package operator
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
+
+	"github.com/jboss-fuse/yaks/pkg/apis"
+	"github.com/jboss-fuse/yaks/pkg/controller"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
+	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+)
+
+// Change below variables to serve metrics on different host or port.
+var (
+	metricsHost               = "0.0.0.0"
+	metricsPort         int32 = 8383
+	operatorMetricsPort int32 = 8686
+)
+var log = logf.Log.WithName("cmd")
+
+func printVersion() {
+	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+}
+
+func Run() {
+	// Add the zap logger flag set to the CLI. The flag set must
+	// be added before calling pflag.Parse().
+	pflag.CommandLine.AddFlagSet(zap.FlagSet())
+
+	// Add flags registered by imported packages (e.g. glog and
+	// controller-runtime)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	pflag.Parse()
+
+	// Use a zap logr.Logger implementation. If none of the zap
+	// flags are configured (or if the zap flag set is not being
+	// used), this defaults to a production zap logger.
+	//
+	// The logger instantiated here can be changed to any logger
+	// implementing the logr.Logger interface. This logger will
+	// be propagated through the whole operator, generating
+	// uniform and structured logs.
+	logf.SetLogger(zap.Logger())
+
+	printVersion()
+
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		log.Error(err, "Failed to get watch namespace")
+		os.Exit(1)
+	}
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	ctx := context.TODO()
+	// Become the leader before proceeding
+	err = leader.Become(ctx, "yaks-lock")
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, manager.Options{
+		Namespace:          namespace,
+		MapperProvider:     restmapper.NewDynamicRESTMapper,
+		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+	})
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	log.Info("Registering Components.")
+
+	// Setup Scheme for all resources
+	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup all Controllers
+	if err := controller.AddToManager(mgr); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	if err = serveCRMetrics(cfg); err != nil {
+		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
+	}
+
+	// Add to the below struct any other metrics ports you want to expose.
+	servicePorts := []v1.ServicePort{
+		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
+	}
+	// Create Service object to expose the metrics port(s).
+	_, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	if err != nil {
+		log.Info(err.Error())
+	}
+
+	log.Info("Starting the Cmd.")
+
+	// Start the Cmd
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "Manager exited non-zero")
+		os.Exit(1)
+	}
+}
+
+// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
+// It serves those metrics on "http://metricsHost:operatorMetricsPort".
+func serveCRMetrics(cfg *rest.Config) error {
+	// Below function returns filtered operator/CustomResource specific GVKs.
+	// For more control override the below GVK list with your own custom logic.
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
+	if err != nil {
+		return err
+	}
+	// Get the namespace the operator is currently deployed in.
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return err
+	}
+	// To generate metrics in other namespaces, add the values below.
+	ns := []string{operatorNs}
+	// Generate and serve custom resource specific metrics.
+	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -46,10 +46,12 @@ func newCmdTest(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	}
 
 	cmd := cobra.Command{
-		Use:   "test [test file to execute]",
-		Short: "Execute a test on Kubernetes",
-		Long:  `Deploys and execute a pod on Kubernetes for running tests.`,
-		RunE:  options.run,
+		PersistentPreRunE: options.preRun,
+		Use:               "test [test file to execute]",
+		Short:             "Execute a test on Kubernetes",
+		Long:              `Deploys and execute a pod on Kubernetes for running tests.`,
+		PreRunE:           options.validateArgs,
+		RunE:              options.run,
 	}
 
 	return &cmd

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/jboss-fuse/yaks/pkg/client"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func (command *RootCmdOptions) preRun(cmd *cobra.Command, _ []string) error {
+	if command.Namespace == "" {
+		current, err := client.GetCurrentNamespace(command.KubeConfig)
+		if err != nil {
+			return errors.Wrap(err, "cannot get current namespace")
+		}
+		err = cmd.Flag("namespace").Value.Set(current)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetCmdClient returns the client that can be used from command line tools
+func (command *RootCmdOptions) GetCmdClient() (client.Client, error) {
+	// Get the pre-computed client
+	if command._client != nil {
+		return command._client, nil
+	}
+	var err error
+	command._client, err = command.NewCmdClient()
+	return command._client, err
+}
+
+// NewCmdClient returns a new client that can be used from command line tools
+func (command *RootCmdOptions) NewCmdClient() (client.Client, error) {
+	return client.NewOutOfClusterClient(command.KubeConfig)
+}


### PR DESCRIPTION
Now `yaks operator` runs the operator (used only internally inside openshift), so there's now a single binary file.

I've added the release command and released docker.io/yaks/yaks:0.0.1 (send me your docker hub id to be added to the docker org and run the releases yourself).

Added cross-compilation. Binaries need to be uploaded manually to [github releases](https://github.com/jboss-fuse/yaks/releases).

assign: @lburgazzoli, @christophd, @jamesnetherton 