### PR TITLE
#4 First version of JDBC verification steps

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -40,6 +40,7 @@
         <cucumber.version>3.0.2</cucumber.version>
         <junit.version>5.5.0</junit.version>
         <kubernetes-client.version>4.3.0</kubernetes-client.version>
+        <postgresql.version>9.4.1212</postgresql.version>
 
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -69,6 +70,11 @@
             <dependency>
                 <groupId>dev.yaks</groupId>
                 <artifactId>yaks-testing-camel-k</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.yaks</groupId>
+                <artifactId>yaks-testing-jdbc</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -126,6 +132,7 @@
         <module>yaks-testing</module>
         <module>yaks-testing-camel-k</module>
         <module>yaks-testing-http</module>
+        <module>yaks-testing-jdbc</module>
     </modules>
 
     <profiles>

--- a/java/yaks-testing-jdbc/pom.xml
+++ b/java/yaks-testing-jdbc/pom.xml
@@ -26,41 +26,38 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>yaks-testing</artifactId>
+    <artifactId>yaks-testing-jdbc</artifactId>
 
     <dependencies>
 
-        <!-- ****************************** -->
-        <!--                                -->
-        <!-- RUNTIME                        -->
-        <!--                                -->
-        <!-- ****************************** -->
-
-        <dependency>
-            <groupId>dev.yaks</groupId>
-            <artifactId>yaks-testing-camel-k</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>dev.yaks</groupId>
-            <artifactId>yaks-testing-http</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>dev.yaks</groupId>
-            <artifactId>yaks-testing-jdbc</artifactId>
-        </dependency>
-
-        <!-- ****************************** -->
-        <!--                                -->
-        <!-- OTHERS                         -->
-        <!--                                -->
-        <!-- ****************************** -->
-
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-junit</artifactId>
+            <artifactId>cucumber-java</artifactId>
             <version>${cucumber.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-cucumber</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-core</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.consol.citrus</groupId>
+            <artifactId>citrus-java-dsl</artifactId>
+            <version>${citrus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
         </dependency>
 
     </dependencies>

--- a/java/yaks-testing-jdbc/src/main/java/dev/yaks/testing/jdbc/JdbcSteps.java
+++ b/java/yaks-testing-jdbc/src/main/java/dev/yaks/testing/jdbc/JdbcSteps.java
@@ -1,0 +1,136 @@
+package dev.yaks.testing.jdbc;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.annotations.CitrusFramework;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.dsl.runner.TestRunner;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import io.cucumber.datatable.DataTable;
+import org.postgresql.Driver;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class JdbcSteps {
+
+    @CitrusResource
+    private TestRunner runner;
+
+    @CitrusFramework
+    private Citrus citrus;
+
+    private DataSource dataSource;
+    private List<String> sqlQueryStatements = new ArrayList<>();
+
+    @Before
+    public void before(Scenario scenario) {
+        if (dataSource == null && citrus.getApplicationContext().getBeansOfType(DataSource.class).size() == 1L) {
+            dataSource = citrus.getApplicationContext().getBean(DataSource.class);
+        }
+    }
+
+    @Given("^(?:D|d)ata source: ([^\"\\s]+)$")
+    public void setDataSource(String id) {
+        if (!citrus.getApplicationContext().containsBean(id)) {
+            throw new CitrusRuntimeException("Unable to find data source for id: " + id);
+        }
+
+        dataSource = citrus.getApplicationContext().getBean(id, DataSource.class);
+    }
+
+    @Given("^(?:D|d)atabase connection$")
+    public void setConnection(DataTable properties) {
+        Map<String, String> connectionProps = properties.asMap(String.class, String.class);
+
+        String driver = connectionProps.getOrDefault("driver", Driver.class.getName());
+        String url = connectionProps.getOrDefault("url", "");
+        String username = connectionProps.getOrDefault("username", "test");
+        String password = connectionProps.getOrDefault("password", "test");
+        boolean suppressClose = Boolean.parseBoolean(connectionProps.getOrDefault("suppressClose", Boolean.TRUE.toString()));
+
+        SingleConnectionDataSource singleConnectionDataSource = new SingleConnectionDataSource(url, username, password, suppressClose);
+        singleConnectionDataSource.setDriverClassName(driver);
+        this.dataSource = singleConnectionDataSource;
+    }
+
+    @Given("^SQL query: (.+)$")
+    public void addQueryStatement(String statement) {
+        if (statement.trim().toUpperCase().startsWith("SELECT")) {
+            sqlQueryStatements.add(statement);
+        } else {
+            throw new CitrusRuntimeException("Invalid SQL query - please use proper 'SELECT' statement");
+        }
+    }
+
+    @Given("^SQL query statements:$")
+    public void addQueryStatements(DataTable statements) {
+        statements.asList().forEach(this::addQueryStatement);
+    }
+
+    @Then("^verify column ([^\"\\s]+)=(.+)$")
+    public void verifyColumn(String name, String value) {
+        runner.query(action -> action.dataSource(dataSource)
+                                     .statements(sqlQueryStatements)
+                                     .validate(name, value));
+        sqlQueryStatements.clear();
+    }
+
+    @Then("^verify columns$")
+    public void verifyResultSet(DataTable expectedResults) {
+        runner.query(action -> {
+            action.dataSource(dataSource);
+            action.statements(sqlQueryStatements);
+
+            List<List<String>> rows = expectedResults.asLists(String.class);
+            rows.forEach(row -> {
+                if (!row.isEmpty()) {
+                    String columnName = row.remove(0);
+                    action.validate(columnName, row.toArray(new String[]{}));
+                }
+            });
+        });
+
+        sqlQueryStatements.clear();
+    }
+
+    @Then("^verify result set$")
+    public void verifyResultSet(String verifyScript) {
+        runner.query(action -> action.dataSource(dataSource)
+                                     .statements(sqlQueryStatements)
+                                     .groovy(verifyScript));
+
+        sqlQueryStatements.clear();
+    }
+
+    @When("^(?:execute |perform )?SQL update: (.+)$")
+    public void executeUpdate(String statement) {
+        if (statement.trim().toUpperCase().startsWith("SELECT")) {
+            throw new CitrusRuntimeException("Invalid SQL update statement - please use SQL query for 'SELECT' statements");
+        } else {
+            runner.sql(action -> action.dataSource(dataSource)
+                                        .statement(statement));
+        }
+
+    }
+
+    @When("^(?:execute |perform )?SQL update$")
+    public void executeUpdateMultiline(String statement) {
+        executeUpdate(statement);
+    }
+
+    @When("^(?:execute |perform )?SQL updates$")
+    public void executeUpdates(DataTable statements) {
+        statements.asList().forEach(this::executeUpdate);
+    }
+}

--- a/java/yaks-testing/src/main/java/dev/yaks/testing/TestRunner.java
+++ b/java/yaks-testing/src/main/java/dev/yaks/testing/TestRunner.java
@@ -39,6 +39,9 @@ public class TestRunner {
         params.add("--glue");
         params.add("dev.yaks.testing.camel.k");
 
+        params.add("--glue");
+        params.add("dev.yaks.testing.jdbc");
+
         params.add("--plugin");
         params.add("com.consol.citrus.cucumber.CitrusReporter");
 


### PR DESCRIPTION
This PR adds JDBC verification Cucumber steps. These can be used in a feature scenario to access the DB and verify SQL result sets:

```
Feature: JDBC connectitiy

  Background:
    Given Database connection
      | url       | jdbc:postgresql://localhost:5432/sampledb |
      | username  | sampledb |
      | password  | ***** |

  Scenario: INSERT task
    Given variables
      | todoId  | citrus:randomNumber(4) |
      | task    | Test CamelK with YAKS! |
    Then SQL update: INSERT INTO todo (id, task, completed) VALUES (${todoId}, '${task}', 0)
    
  Scenario: SELECT and verify task
    Given variable taskId is "citrus:randomNumber(10)"
    When SQL query: SELECT COUNT(task) AS FOUND_TASKS FROM todo WHERE task='Task #${taskId}'
    Then verify column FOUND_TASKS=1
```

Also supported multiple SQL statements:

```
Given SQL updates 
      | INSERT INTO todo (id, task, completed) VALUES (1, 'Task 1', 0) |
      | INSERT INTO todo (id, task, completed) VALUES (2, 'Task 2', 0) |
      | INSERT INTO todo (id, task, completed) VALUES (3, 'Task 3', 0) |
```

And verifications:

```
Given SQL query: SELECT * FROM todo WHERE id='${id}'
    Then verify columns 
      | ID        | ${id} |
      | TASK      | My Task |
      | COMPLETED | 0 |
```

Still open questions:
- How to choose DB driver other than Postgresql
- How to externalize connection credentials
- How to decorate SQL syntax using an optional key-value language