### PR TITLE
Fix #6. Create a CSV for Operator Marketplace

### DIFF
--- a/deploy/olm-catalog/csv-config.yaml
+++ b/deploy/olm-catalog/csv-config.yaml
@@ -1,0 +1,5 @@
+operator-path: deploy/operator.yaml
+crd-cr-paths:
+  - deploy/crds
+role-paths:
+  - deploy/role.yaml

--- a/deploy/olm-catalog/yaks/0.0.1/yaks.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/yaks/0.0.1/yaks.v0.0.1.clusterserviceversion.yaml
@@ -1,0 +1,239 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [{
+        "apiVersion": "yaks.dev/v1alpha1",
+        "kind": "Test",
+        "metadata": {
+          "name": "example-test"
+        },
+        "spec": {
+          "source": {
+            "content": "# Add example Gherkin feature code to define a test",
+            "language": "feature",
+            "name":"example.feature"
+          }
+        }
+      }]
+    capabilities: Basic Install
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: docker.io/apache/yaks:0.0.1
+    createdAt: "2019-01-08T10:52:00Z"
+    description: YAKS is a framework to help you test Apache Camel integrations running on Openshift & Kubernetes.
+    repository: https://github.com/jboss-fuse/yaks
+    support: Red Hat Fuse
+  name: yaks.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Test
+      description: A YAKS test
+      displayName: YAKS Test
+      name: tests.yaks.dev
+      version: v1alpha1
+      specDescriptors:
+        - description: The test source
+          displayName: Source
+          path: source
+        - description: The name of the test source
+          displayName: Name
+          path: source.name
+        - description: The language of the test source
+          displayName: Language
+          path: source.language
+        - description: The content of the test source
+          displayName: Content
+          path: source.content
+      statusDescriptors:
+        - description: The phase that the test is currently in
+          displayName: Phase
+          path: phase
+        - description: The unique ID of the test
+          displayName: Test ID
+          path: testID
+        - description: The version of YAKS which ran the test
+          displayName: Version
+          path: version
+  description: |
+    YAKS (Yet Another Kamel Subproject)
+    ===================================
+
+    YAKS is a framework to help you test Apache Camel integrations running on Openshift & Kubernetes.
+
+    ## Running a YAKS test
+
+    With the YAKS operator installed, you can run tests against deployed integrations by creating a `Test` resource.
+
+    Tests are defined using [Gherkin](https://cucumber.io/docs/gherkin/) syntax. YAKS provides a set of custom steps which
+    help to test for whether an integration is running, is producing some expected output and also whether an HTTP endpoint
+    returns an expected response.
+
+    The example below assumes a running integration named 'simple' and has printed 'Hello Camel' to STDOUT.
+    ```
+    apiVersion: yaks.dev/v1alpha1
+    kind: Test
+    metadata:
+      name: example-test
+    spec:
+      source:
+        name: simple.feature
+        language: feature
+        content: |-
+          Feature: integration runs
+
+            Scenario:
+              Given integration simple is running
+              Then integration simple should print Hello Camel
+    ```
+  displayName: Yaks Operator
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iCiAgIHhtbG5zOmNjPSJodHRwOi8vY3JlYXRpdmVjb21tb25zLm9yZy9ucyMiCiAgIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyIKICAgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgd2lkdGg9IjEyMG1tIgogICBoZWlnaHQ9IjEyMG1tIgogICB2aWV3Qm94PSIwIDAgMTIwIDEyMCIKICAgdmVyc2lvbj0iMS4xIgogICBpZD0ic3ZnOCIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMC45Mi4zICgyNDA1NTQ2LCAyMDE4LTAzLTExKSIKICAgc29kaXBvZGk6ZG9jbmFtZT0ibG9nby5zdmciPgogIDxkZWZzCiAgICAgaWQ9ImRlZnMyIj4KICAgIDxsaW5lYXJHcmFkaWVudAogICAgICAgaW5rc2NhcGU6Y29sbGVjdD0iYWx3YXlzIgogICAgICAgaWQ9ImxpbmVhckdyYWRpZW50NDU0OS03Ij4KICAgICAgPHN0b3AKICAgICAgICAgc3R5bGU9InN0b3AtY29sb3I6I2ZlOGMzMztzdG9wLW9wYWNpdHk6MSIKICAgICAgICAgb2Zmc2V0PSIwIgogICAgICAgICBpZD0ic3RvcDQ1NDUiIC8+CiAgICAgIDxzdG9wCiAgICAgICAgIHN0eWxlPSJzdG9wLWNvbG9yOiNkYTY4MGY7c3RvcC1vcGFjaXR5OjEiCiAgICAgICAgIG9mZnNldD0iMSIKICAgICAgICAgaWQ9InN0b3A0NTQ3IiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDxyYWRpYWxHcmFkaWVudAogICAgICAgaW5rc2NhcGU6Y29sbGVjdD0iYWx3YXlzIgogICAgICAgeGxpbms6aHJlZj0iI2xpbmVhckdyYWRpZW50NDU0OS03IgogICAgICAgaWQ9InJhZGlhbEdyYWRpZW50NDU1MyIKICAgICAgIGN4PSI1MCIKICAgICAgIGN5PSI1MCIKICAgICAgIGZ4PSI1MCIKICAgICAgIGZ5PSI1MCIKICAgICAgIHI9IjQ2IgogICAgICAgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiCiAgICAgICBncmFkaWVudFRyYW5zZm9ybT0ibWF0cml4KC0wLjkxNDk1NDY2LDAsMCwtMS4yMTczOTEzLDEwNS43NDc3MywxMDAuODY5NTcpIiAvPgogIDwvZGVmcz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9ImJhc2UiCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIgogICAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICAgIGJvcmRlcm9wYWNpdHk9IjEuMCIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6em9vbT0iMS40IgogICAgIGlua3NjYXBlOmN4PSIxMTUuMTA3NTciCiAgICAgaW5rc2NhcGU6Y3k9IjIzMS4xNDQ1NCIKICAgICBpbmtzY2FwZTpkb2N1bWVudC11bml0cz0ibW0iCiAgICAgaW5rc2NhcGU6Y3VycmVudC1sYXllcj0ibGF5ZXIyIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9IjE5MjAiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iMTAxNiIKICAgICBpbmtzY2FwZTp3aW5kb3cteD0iMCIKICAgICBpbmtzY2FwZTp3aW5kb3cteT0iMjciCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMSIgLz4KICA8bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGE1Ij4KICAgIDxyZGY6UkRGPgogICAgICA8Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+CiAgICAgICAgPGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+CiAgICAgICAgPGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPgogICAgICAgIDxkYzp0aXRsZSAvPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZwogICAgIGlua3NjYXBlOmxhYmVsPSJMYXllciAxIgogICAgIGlua3NjYXBlOmdyb3VwbW9kZT0ibGF5ZXIiCiAgICAgaWQ9ImxheWVyMSIKICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLC0xNzcpIj4KICAgIDxnCiAgICAgICBpbmtzY2FwZTpncm91cG1vZGU9ImxheWVyIgogICAgICAgaWQ9ImxheWVyMiIKICAgICAgIGlua3NjYXBlOmxhYmVsPSJMYXllciAyIgogICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMCwxOTcpIj4KICAgICAgPHJlY3QKICAgICAgICAgc3R5bGU9Im9wYWNpdHk6MC45Nzk5OTk5ODtmaWxsOnVybCgjcmFkaWFsR3JhZGllbnQ0NTUzKTtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTtzdHJva2Utd2lkdGg6Ni4wOTA0NDc5O3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDo0O3N0cm9rZS1kYXNoYXJyYXk6bm9uZTtzdHJva2Utb3BhY2l0eToxO3BhaW50LW9yZGVyOnN0cm9rZSBmaWxsIG1hcmtlcnMiCiAgICAgICAgIGlkPSJyZWN0ODQ0IgogICAgICAgICB3aWR0aD0iMTEyIgogICAgICAgICBoZWlnaHQ9IjExMiIKICAgICAgICAgeD0iNCIKICAgICAgICAgeT0iLTE2IgogICAgICAgICByeT0iMTMuOTQzNzM3IiAvPgogICAgICA8dGV4dAogICAgICAgICB4bWw6c3BhY2U9InByZXNlcnZlIgogICAgICAgICBzdHlsZT0iZm9udC1zdHlsZTpub3JtYWw7Zm9udC12YXJpYW50Om5vcm1hbDtmb250LXdlaWdodDpub3JtYWw7Zm9udC1zdHJldGNoOm5vcm1hbDtmb250LXNpemU6NTAuMzUyMzk3OTJweDtsaW5lLWhlaWdodDoxLjI1O2ZvbnQtZmFtaWx5Ok1lZXJhOy1pbmtzY2FwZS1mb250LXNwZWNpZmljYXRpb246TWVlcmE7bGV0dGVyLXNwYWNpbmc6MHB4O3dvcmQtc3BhY2luZzowcHg7ZmlsbDojMDMwMzQwO2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lO3N0cm9rZS13aWR0aDowLjI2MjI1MjA2IgogICAgICAgICB4PSI0MS4xNTc3MDMiCiAgICAgICAgIHk9IjQ0LjcwMTc0IgogICAgICAgICBpZD0idGV4dDgzNCIKICAgICAgICAgdHJhbnNmb3JtPSJzY2FsZSgxLjAzNTAyMTUsMC45NjYxNjM1MSkiPjx0c3BhbgogICAgICAgICAgIHNvZGlwb2RpOnJvbGU9ImxpbmUiCiAgICAgICAgICAgaWQ9InRzcGFuODMyIgogICAgICAgICAgIHg9IjQxLjE1NzcwMyIKICAgICAgICAgICB5PSI0NC43MDE3NCIKICAgICAgICAgICBzdHlsZT0iZm9udC1zdHlsZTpub3JtYWw7Zm9udC12YXJpYW50Om5vcm1hbDtmb250LXdlaWdodDpib2xkO2ZvbnQtc3RyZXRjaDpub3JtYWw7Zm9udC1zaXplOjU1Ljk0NzEwNTQxcHg7Zm9udC1mYW1pbHk6J0NvdXJpZXIgMTAgUGl0Y2gnOy1pbmtzY2FwZS1mb250LXNwZWNpZmljYXRpb246J0NvdXJpZXIgMTAgUGl0Y2ggQm9sZCc7ZmlsbDojMDMwMzQwO2ZpbGwtb3BhY2l0eToxO3N0cm9rZS13aWR0aDowLjI2MjI1MjA2Ij4tPC90c3Bhbj48L3RleHQ+CiAgICA8L2c+CiAgICA8dGV4dAogICAgICAgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIKICAgICAgIHN0eWxlPSJmb250LXN0eWxlOm5vcm1hbDtmb250LXZhcmlhbnQ6bm9ybWFsO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1zdHJldGNoOm5vcm1hbDtmb250LXNpemU6ODYuNDE3NTU2NzZweDtsaW5lLWhlaWdodDoxLjI1O2ZvbnQtZmFtaWx5OidDb3VyaWVyIDEwIFBpdGNoJzstaW5rc2NhcGUtZm9udC1zcGVjaWZpY2F0aW9uOidDb3VyaWVyIDEwIFBpdGNoIEJvbGQnO2xldHRlci1zcGFjaW5nOjBweDt3b3JkLXNwYWNpbmc6MHB4O2ZpbGw6I2Y1ZmZmZjtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTtzdHJva2Utd2lkdGg6MC40NTAwOTEzOSIKICAgICAgIHg9IjE5MS44NDY5NyIKICAgICAgIHk9Ii0zOS4wOTc3NzUiCiAgICAgICBpZD0idGV4dDgxNyIKICAgICAgIHRyYW5zZm9ybT0ibWF0cml4KDAsMC45MzgyNDc3OCwtMS4wNjU4MTY1LDAsMCwwKSI+PHRzcGFuCiAgICAgICAgIHNvZGlwb2RpOnJvbGU9ImxpbmUiCiAgICAgICAgIGlkPSJ0c3BhbjgxNSIKICAgICAgICAgeD0iMTkxLjg0Njk3IgogICAgICAgICB5PSItMzkuMDk3Nzc1IgogICAgICAgICBzdHlsZT0iZm9udC1zdHlsZTpub3JtYWw7Zm9udC12YXJpYW50Om5vcm1hbDtmb250LXdlaWdodDpib2xkO2ZvbnQtc3RyZXRjaDpub3JtYWw7Zm9udC1mYW1pbHk6J0NvdXJpZXIgMTAgUGl0Y2gnOy1pbmtzY2FwZS1mb250LXNwZWNpZmljYXRpb246J0NvdXJpZXIgMTAgUGl0Y2ggQm9sZCc7ZmlsbDojZjVmZmZmO2ZpbGwtb3BhY2l0eToxO3N0cm9rZS13aWR0aDowLjQ1MDA5MTM5Ij5dPC90c3Bhbj48L3RleHQ+CiAgICA8dGV4dAogICAgICAgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIKICAgICAgIHN0eWxlPSJmb250LXN0eWxlOm5vcm1hbDtmb250LXZhcmlhbnQ6bm9ybWFsO2ZvbnQtd2VpZ2h0Om5vcm1hbDtmb250LXN0cmV0Y2g6bm9ybWFsO2ZvbnQtc2l6ZToxMTYuNjI2OTE0OThweDtsaW5lLWhlaWdodDoxLjI1O2ZvbnQtZmFtaWx5Ok1lZXJhOy1pbmtzY2FwZS1mb250LXNwZWNpZmljYXRpb246TWVlcmE7bGV0dGVyLXNwYWNpbmc6MHB4O3dvcmQtc3BhY2luZzowcHg7ZmlsbDojMDMwMzQwO2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lO3N0cm9rZS13aWR0aDowLjYwNzQzMTk1IgogICAgICAgeD0iMjExLjQ2NTgxIgogICAgICAgeT0iLTMwLjQwNjMwMSIKICAgICAgIGlkPSJ0ZXh0ODE3LTMiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLDAuOTI0Njg0OCwtMS4wODE0NDk2LDAsMCwwKSI+PHRzcGFuCiAgICAgICAgIHNvZGlwb2RpOnJvbGU9ImxpbmUiCiAgICAgICAgIGlkPSJ0c3BhbjgxNS0zIgogICAgICAgICB4PSIyMTEuNDY1ODEiCiAgICAgICAgIHk9Ii0zMC40MDYzMDEiCiAgICAgICAgIHN0eWxlPSJmb250LXN0eWxlOm5vcm1hbDtmb250LXZhcmlhbnQ6bm9ybWFsO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1zdHJldGNoOm5vcm1hbDtmb250LWZhbWlseTonQ291cmllciAxMCBQaXRjaCc7LWlua3NjYXBlLWZvbnQtc3BlY2lmaWNhdGlvbjonQ291cmllciAxMCBQaXRjaCBCb2xkJztmaWxsOiMwMzAzNDA7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlLXdpZHRoOjAuNjA3NDMxOTUiPjo8L3RzcGFuPjwvdGV4dD4KICAgIDx0ZXh0CiAgICAgICB4bWw6c3BhY2U9InByZXNlcnZlIgogICAgICAgc3R5bGU9ImZvbnQtc3R5bGU6bm9ybWFsO2ZvbnQtdmFyaWFudDpub3JtYWw7Zm9udC13ZWlnaHQ6bm9ybWFsO2ZvbnQtc3RyZXRjaDpub3JtYWw7Zm9udC1zaXplOjY1LjQ4MzU1ODY1cHg7bGluZS1oZWlnaHQ6MS4yNTtmb250LWZhbWlseTpNZWVyYTstaW5rc2NhcGUtZm9udC1zcGVjaWZpY2F0aW9uOk1lZXJhO2xldHRlci1zcGFjaW5nOjBweDt3b3JkLXNwYWNpbmc6MHB4O2ZpbGw6I2ZmZmZmZjtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTtzdHJva2Utd2lkdGg6MC4zNDEwNjAxNjsiCiAgICAgICB4PSIyNzkuODUwNTYiCiAgICAgICB5PSItMzMuMzc0Nzg2IgogICAgICAgaWQ9InRleHQ4MTctMzIiCiAgICAgICB0cmFuc2Zvcm09Im1hdHJpeCgwLDAuODkxMzAzOTcsLTEuMTIxOTUxNywwLDAsMCkiPjx0c3BhbgogICAgICAgICBzb2RpcG9kaTpyb2xlPSJsaW5lIgogICAgICAgICBpZD0idHNwYW44MTUtNiIKICAgICAgICAgeD0iMjc5Ljg1MDU2IgogICAgICAgICB5PSItMzMuMzc0Nzg2IgogICAgICAgICBzdHlsZT0iZm9udC1zdHlsZTpub3JtYWw7Zm9udC12YXJpYW50Om5vcm1hbDtmb250LXdlaWdodDpib2xkO2ZvbnQtc3RyZXRjaDpub3JtYWw7Zm9udC1mYW1pbHk6J0NvdXJpZXIgMTAgUGl0Y2gnOy1pbmtzY2FwZS1mb250LXNwZWNpZmljYXRpb246J0NvdXJpZXIgMTAgUGl0Y2ggQm9sZCc7ZmlsbDojZmZmZmZmO2ZpbGwtb3BhY2l0eToxO3N0cm9rZS13aWR0aDowLjM0MTA2MDE2OyI+Jmd0OzwvdHNwYW4+PC90ZXh0PgogIDwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: yaks
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: yaks
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: yaks
+            spec:
+              containers:
+              - command:
+                - yaks
+                - operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: yaks
+                image: docker.io/yaks/yaks:0.0.1
+                imagePullPolicy: IfNotPresent
+                name: yaks
+                resources: {}
+              serviceAccountName: yaks
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          - pods/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - yaks.dev
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: yaks
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+    - yaks
+    - testing
+    - microservices
+  labels:
+    name: yaks-operator
+  links:
+    - name: YAKS source code repository
+      url: https://github.com/jboss-fuse/yaks
+# TODO: To be confirmed...
+#  maintainers:
+#    - email:
+#      name:
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 0.0.1

--- a/deploy/olm-catalog/yaks/0.0.1/yaks_v1alpha1_test_crd.yaml
+++ b/deploy/olm-catalog/yaks/0.0.1/yaks_v1alpha1_test_crd.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tests.yaks.dev
+spec:
+  group: yaks.dev
+  names:
+    kind: Test
+    listKind: TestList
+    plural: tests
+    singular: test
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+    - name: Phase
+      type: string
+      description: The test phase
+      JSONPath: .status.phase
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            source:
+              properties:
+                content:
+                  type: string
+                language:
+                  type: string
+                name:
+                  type: string
+              type: object
+          type: object
+        status:
+          properties:
+            phase:
+              type: string
+            testID:
+              type: string
+            version:
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/deploy/olm-catalog/yaks/yaks.package.yaml
+++ b/deploy/olm-catalog/yaks/yaks.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: yaks.v0.0.1
+  name: alpha
+defaultChannel: alpha
+packageName: yaks


### PR DESCRIPTION
Here's an initial stab at a CSV for YAKS.

I did my best with the wording for the descriptions & examples. Since this is just a POC, for now I chose some arbitrary values for fields like `support` / `provider` / `categories` and commented out `maintainer`, until we have a better idea of what those values will be.

I created a YAKS organization on quay.io. If anyone would like admin access to it, let me know your user id.

To see YAKS show up in OpenShift create an `operatorsource`:

```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: yaks
  namespace: openshift-marketplace
spec:
  type: appregistry
  endpoint: https://quay.io/cnr
  registryNamespace: yaks
  displayName: "YAKS Operators"
  publisher: "Red Hat"
```

Then after a short time, the operator should show up.

![yaks-operatorhub](https://user-images.githubusercontent.com/4721408/62353295-41340100-b502-11e9-8d52-952ec0531386.png)
