### PR TITLE
Add possibility to plug External steps

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-source_up
-
-export PATH=$PATH:$PWD

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_up
+
+export PATH=$PATH:$PWD

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/_output
 /yaks-*
 
 target/
+
+.envrc

--- a/README.md
+++ b/README.md
@@ -236,9 +236,10 @@ It's often useful to plug some custom steps into the testing environment. Custom
 tests short and self-explanatory and at the same time help teams to add generic assertions that are meaningful in their 
 environment.
 
-To add custom steps in Yaks, please clone/fork the [yaks extension](https://github.com/nicolaferraro/yaks-extension).
+To add custom steps in Yaks, you can fork + clone the [yaks extension](https://github.com/nicolaferraro/yaks-extension) repository, that provides
+an example of how to do that.
 
-You can add your own steps and follow the instructions in that repository to install them in the Yaks environment.
+You can add your own steps to that project and follow the instructions in order to install them in the Yaks environment.
 
 ## For Yaks Developers
 

--- a/README.md
+++ b/README.md
@@ -232,8 +232,13 @@ There's also an example that uses [JDBC and REST together](/examples/task-api.fe
 
 ### Using custom steps
 
-... coming soon ...
+It's often useful to plug some custom steps into the testing environment. Custom steps help keeping the 
+tests short and self-explanatory and at the same time help teams to add generic assertions that are meaningful in their 
+environment.
 
+To add custom steps in Yaks, please clone/fork the [yaks extension](https://github.com/nicolaferraro/yaks-extension).
+
+You can add your own steps and follow the instructions in that repository to install them in the Yaks environment.
 
 ## For Yaks Developers
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,6 +18,6 @@ RUN  /usr/local/bin/user_setup
 # TODO create a more efficient way to manage dependencies than to hardcode them
 ADD build/_maven_dependencies /deployments/dependencies
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+# Let's not use ENTRYPOINT so we can override libs in the base image
 
 USER ${USER_UID}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"os"
+
+	"github.com/jboss-fuse/yaks/version"
+)
+
+func GetTestBaseImage() string {
+	customEnv := os.Getenv("TEST_BASE_IMAGE")
+	if customEnv != "" {
+		return customEnv
+	}
+	return getDefaultTestBaseImage()
+}
+
+func getDefaultTestBaseImage() string {
+	return "yaks/yaks:" + version.Version
+}

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -21,9 +21,9 @@ import (
 	"context"
 
 	"github.com/jboss-fuse/yaks/pkg/apis/yaks/v1alpha1"
+	"github.com/jboss-fuse/yaks/pkg/config"
 	"github.com/jboss-fuse/yaks/pkg/install"
 	"github.com/jboss-fuse/yaks/pkg/util/kubernetes"
-	"github.com/jboss-fuse/yaks/version"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/rbac/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,7 +81,7 @@ func (action *startAction) newTestingPod(ctx context.Context, test *v1alpha1.Tes
 			Namespace: test.Namespace,
 			Name:      TestPodNameFor(test),
 			Labels: map[string]string{
-				"yaks.dev/app":    "yaks",
+				"yaks.dev/app":     "yaks",
 				"yaks.dev/test":    test.Name,
 				"yaks.dev/test-id": test.Status.TestID,
 			},
@@ -101,7 +101,7 @@ func (action *startAction) newTestingPod(ctx context.Context, test *v1alpha1.Tes
 			Containers: []v1.Container{
 				{
 					Name:            "test",
-					Image:           "yaks/yaks:" + version.Version,
+					Image:           config.GetTestBaseImage(),
 					Command:         []string{"/usr/local/s2i/run"},
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts: []v1.VolumeMount{
@@ -157,7 +157,7 @@ func (action *startAction) newTestingConfigMap(ctx context.Context, test *v1alph
 			Namespace: test.Namespace,
 			Name:      TestResourceNameFor(test),
 			Labels: map[string]string{
-				"yaks.dev/app":    "yaks",
+				"yaks.dev/app":     "yaks",
 				"yaks.dev/test":    test.Name,
 				"yaks.dev/test-id": test.Status.TestID,
 			},


### PR DESCRIPTION
This adds the possibility to add custom steps as defined in https://github.com/nicolaferraro/yaks-extension

In order for this to work, we need to refresh the yaks:yaks:0.0.1 image with latest changes (which I'll do after merge).

