### PR TITLE
feat: Write custom termination logs so test failure cause is reported

### DIFF
--- a/java/yaks-testing/src/main/java/dev/yaks/testing/TestReporter.java
+++ b/java/yaks-testing/src/main/java/dev/yaks/testing/TestReporter.java
@@ -1,0 +1,80 @@
+package dev.yaks.testing;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.TestResult;
+import com.consol.citrus.cucumber.CitrusReporter;
+import com.consol.citrus.report.AbstractTestReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reporter writing test results summary to termination log. This information will be accessible via
+ * pod container status details.
+ *
+ * @author Christoph Deppisch
+ */
+public class TestReporter extends CitrusReporter {
+
+    /** Logger */
+    private static final Logger LOG = LoggerFactory.getLogger(TestReporter.class);
+
+    private static final String TERMINATION_LOG_DEFAULT = "/dev/termination-log";
+    private static final String TERMINATION_LOG_PROPERTY = "yaks.termination.log";
+    private static final String TERMINATION_LOG_ENV = "YAKS_TERMINATION_LOG";
+
+    public TestReporter() {
+        TerminationLogReporter reporter = new TerminationLogReporter();
+
+        Citrus.CitrusInstanceManager.addInstanceProcessor(citrus -> {
+            citrus.addTestListener(reporter);
+            citrus.addTestSuiteListener(reporter);
+        });
+    }
+
+    static class TerminationLogReporter extends AbstractTestReporter {
+        @Override
+        public void generateTestResults() {
+            StringJoiner report = new StringJoiner(System.lineSeparator());
+            getTestResults().doWithResults(result -> report.add(getTestResultMessage(result)));
+
+            try (Writer terminationLogWriter = Files.newBufferedWriter(getTerminationLog(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                terminationLogWriter.write(report.toString());
+                terminationLogWriter.flush();
+            } catch (IOException e) {
+                LOG.warn(String.format("Failed to write termination logs to file '%s'", getTerminationLog()), e);
+            }
+        }
+
+        private String getTestResultMessage(TestResult result) {
+            if (result.isSuccess()) {
+                return result.getTestName() + " SUCCESS";
+            } else if (result.isSkipped()) {
+                return result.getTestName() + " SKIPPED";
+            } else if (result.isFailed()) {
+                String errorType = result.getCause().getClass().getName();
+                String errorMessage = Optional.ofNullable(result.getCause().getMessage()).orElse("Unknown error");
+
+                return String.format("%s FAILED - Caused by: %s: %s%n",
+                        result.getTestName(),
+                        errorType,
+                        errorMessage);
+            }
+
+            return result.getTestName() + " UNKNOWN STATE";
+        }
+    }
+
+    private static Path getTerminationLog() {
+        return Paths.get(System.getProperty(TERMINATION_LOG_PROPERTY,
+                System.getenv(TERMINATION_LOG_ENV) != null ? System.getenv(TERMINATION_LOG_ENV) : TERMINATION_LOG_DEFAULT));
+    }
+}

--- a/java/yaks-testing/src/main/java/dev/yaks/testing/TestRunner.java
+++ b/java/yaks-testing/src/main/java/dev/yaks/testing/TestRunner.java
@@ -46,7 +46,7 @@ public class TestRunner {
         params.add("dev.yaks.testing.standard");
 
         params.add("--plugin");
-        params.add("com.consol.citrus.cucumber.CitrusReporter");
+        params.add(TestReporter.class.getName());
 
         params.add("--strict");
 

--- a/java/yaks-testing/src/test/java/dev/yaks/testing/ReportSetupHook.java
+++ b/java/yaks-testing/src/test/java/dev/yaks/testing/ReportSetupHook.java
@@ -1,0 +1,15 @@
+package dev.yaks.testing;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReportSetupHook {
+
+    @Before
+    public void setup(Scenario scenario) {
+        System.setProperty("yaks.termination.log", ReporterTest.TERMINATION_LOG);
+    }
+}

--- a/java/yaks-testing/src/test/java/dev/yaks/testing/ReportVerifyPlugin.java
+++ b/java/yaks-testing/src/test/java/dev/yaks/testing/ReportVerifyPlugin.java
@@ -1,0 +1,33 @@
+package dev.yaks.testing;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import cucumber.api.SummaryPrinter;
+import cucumber.api.event.EventListener;
+import cucumber.api.event.EventPublisher;
+import cucumber.api.event.TestRunFinished;
+import cucumber.api.formatter.Formatter;
+import org.junit.Assert;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ReportVerifyPlugin implements SummaryPrinter, Formatter, EventListener {
+
+    @Override
+    public void setEventPublisher(EventPublisher eventPublisher) {
+        eventPublisher.registerHandlerFor(TestRunFinished.class, event -> {
+            try {
+                Assert.assertTrue(Files.exists(Paths.get(ReporterTest.TERMINATION_LOG)));
+                List<String> lines = Files.readAllLines(Paths.get(ReporterTest.TERMINATION_LOG));
+                Assert.assertEquals(1, lines.size());
+                Assert.assertEquals("dev/yaks/testing/report.feature:3 SUCCESS", lines.get(0));
+            } catch (IOException e) {
+                Assert.fail(e.getMessage());
+            }
+        });
+    }
+}

--- a/java/yaks-testing/src/test/java/dev/yaks/testing/ReporterTest.java
+++ b/java/yaks-testing/src/test/java/dev/yaks/testing/ReporterTest.java
@@ -1,0 +1,18 @@
+package dev.yaks.testing;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christoph Deppisch
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        glue = { "dev.yaks.testing", "com.consol.citrus.cucumber.step.runner.core" },
+        plugin = { "dev.yaks.testing.TestReporter",
+                   "dev.yaks.testing.ReportVerifyPlugin" } )
+public class ReporterTest {
+    static final String TERMINATION_LOG = "target/termination.log";
+}

--- a/java/yaks-testing/src/test/resources/cucumber.properties
+++ b/java/yaks-testing/src/test/resources/cucumber.properties
@@ -1,0 +1,1 @@
+cucumber.api.java.ObjectFactory=cucumber.runtime.java.CitrusObjectFactory

--- a/java/yaks-testing/src/test/resources/dev/yaks/testing/report.feature
+++ b/java/yaks-testing/src/test/resources/dev/yaks/testing/report.feature
@@ -1,0 +1,4 @@
+Feature: Test reporter
+
+  Scenario: Success test
+    Given echo "Yaks rocks!"

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -103,6 +103,8 @@ func (action *startAction) newTestingPod(ctx context.Context, test *v1alpha1.Tes
 					Name:            "test",
 					Image:           config.GetTestBaseImage(),
 					Command:         []string{"/usr/local/s2i/run"},
+					TerminationMessagePolicy: "FallbackToLogsOnError",
+					TerminationMessagePath: "/dev/termination-log",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts: []v1.VolumeMount{
 						{


### PR DESCRIPTION
… as container status message

You can see the custom termination logs when doing

`oc get pod test-jdbc-bleip0t8kplsnet62e50 -o yaml`

You will get the test failure cause as container termination message.

```yaml
state:
      terminated:
        containerID: docker://e0d425746d82d66ba464c3c106269b1157d3cb94616d4a3acac90f4bdc4a364d
        exitCode: 1
        finishedAt: 2019-08-21T11:35:37Z
        message: |
          /etc/yaks/test/..2019_08_21_11_35_31.525541819/jdbc.feature:9 FAILED - Caused by: com.consol.citrus.exceptions.CitrusRuntimeException: org.springframework.jdbc.CannotGetJdbcConnectionException: Failed to obtain JDBC Connection; nested exception is org.postgresql.util.PSQLException: FATAL: password authentication failed for user "sampledb"

          /etc/yaks/test/..2019_08_21_11_35_31.525541819/jdbc.feature:17 FAILED - Caused by: com.consol.citrus.exceptions.CitrusRuntimeException: org.springframework.jdbc.CannotGetJdbcConnectionException: Failed to obtain JDBC Connection; nested exception is org.postgresql.util.PSQLException: FATAL: password authentication failed for user "sampledb"
        reason: Error
        startedAt: 2019-08-21T11:35:32Z
```