### PR TITLE
fix: Missing camel steps as glue in test runner

### DIFF
--- a/java/yaks-testing/src/main/java/dev/yaks/testing/TestRunner.java
+++ b/java/yaks-testing/src/main/java/dev/yaks/testing/TestRunner.java
@@ -40,6 +40,9 @@ public class TestRunner {
         params.add("dev.yaks.testing.swagger");
 
         params.add("--glue");
+        params.add("dev.yaks.testing.camel");
+
+        params.add("--glue");
         params.add("dev.yaks.testing.camel.k");
 
         params.add("--glue");


### PR DESCRIPTION
This enables the user to use the camel steps out of the box