### PR TITLE
fix[ENTESB-12609]: Spring major version conflicts

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -38,8 +38,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j2.version>2.12.0</log4j2.version>
         <citrus.version>2.8.0</citrus.version>
+        <spring.version>5.0.8.RELEASE</spring.version>
         <cucumber.version>3.0.2</cucumber.version>
-        <camel.version>2.21.1</camel.version>
+        <camel.version>2.23.4</camel.version>
         <junit.version>4.12</junit.version>
         <kubernetes-client.version>4.3.0</kubernetes-client.version>
         <postgresql.version>9.4.1212</postgresql.version>

--- a/java/yaks-testing-camel/pom.xml
+++ b/java/yaks-testing-camel/pom.xml
@@ -52,6 +52,43 @@
             <groupId>com.consol.citrus</groupId>
             <artifactId>citrus-camel</artifactId>
             <version>${citrus.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel-spring</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+            <version>${camel.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring</artifactId>
+            <version>${camel.version}</version>
         </dependency>
 
         <!-- Test scope -->


### PR DESCRIPTION
Spring 4.x and 5.x libs were mixed because of older Camel version bringing in Spring 4.x. Fixed by upgrading the Camel version and pin Spring version to the one compatible with Citrus.