### PR TITLE
fix[ENTESB-12540]: #41 Fix test execution when no settings file is provided

### DIFF
--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -202,13 +202,12 @@ func (o *testCmdOptions) newTestSettings() (*v1alpha1.SettingsSpec, error) {
 		return &settings, nil
 	}
 
-	rawName := o.settings
-	settingsFileName := kubernetes.SanitizeFileName(rawName)
-
-	if settingsFileName == "" {
+	if o.settings == "" {
 		return nil, nil
 	}
 
+	rawName := o.settings
+	settingsFileName := kubernetes.SanitizeFileName(rawName)
 	configData, err := o.loadData(rawName)
 
 	if err != nil {


### PR DESCRIPTION
Good to have a sprint demo 😄 