### PR TITLE
fix: return non-zero exit code when test fails

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -46,8 +45,6 @@ func main() {
 
 func exitOnError(err error) {
 	if err != nil {
-		fmt.Println("Error:", err)
-
 		os.Exit(1)
 	}
 }

--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -88,6 +90,13 @@ const (
 	// TestPhaseDeleting --
 	TestPhaseDeleting TestPhase = "Deleting"
 )
+
+func (phase TestPhase) AsError() error {
+	if phase != TestPhasePassed {
+		return fmt.Errorf("Test %s", string(phase))
+	}
+	return nil
+}
 
 type Language string
 

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -190,7 +190,12 @@ func (o *testCmdOptions) createTest(c client.Client, sources []string) (*v1alpha
 		return nil, err
 	}
 
-	return &test, status.AsError()
+	err = status.AsError()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Test %s\n", string(status))
+	return &test, nil
 }
 
 func (o *testCmdOptions) newTestSettings() (*v1alpha1.SettingsSpec, error) {


### PR DESCRIPTION
This should also check if the CI/CD works.. it should trigger a new release with patch version increased.